### PR TITLE
Add generator for full Word book

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,21 @@ Ce dépôt regroupe des fichiers JSON contenant des "monitions" liturgiques.
 ```
 
 Ces fichiers peuvent être consultés tels quels ou importés dans un outil capable de traiter du JSON afin de générer des documents ou sites web.
+
+## Générer un livre Word
+
+Le script `generer_livre.py` parcourt `monitions_livre.json` et assemble toutes les fiches dans un seul document Word. Il nécessite `docxtpl` et `python-docx`.
+
+### Installation des dépendances
+
+```bash
+pip install docxtpl python-docx
+```
+
+### Utilisation
+
+```bash
+python generer_livre.py
+```
+
+Le fichier `monitions_livre.docx` sera créé à la racine du projet, contenant les fiches pour toutes les solennités classées par ordre liturgique.

--- a/generer_livre.py
+++ b/generer_livre.py
@@ -1,0 +1,62 @@
+import json
+import itertools
+import os
+from docxtpl import DocxTemplate
+from docx import Document
+
+TEMPLATE_FILE = "fiche_modele.docx"
+JSON_FILE = "monitions_livre.json"
+OUTPUT_FILE = "monitions_livre.docx"
+
+def titre_lecture(index: int) -> str:
+    if index == 0:
+        return "1re lecture"
+    return f"{index+1}e lecture"
+
+def group_entries(entries):
+    keyfunc = lambda x: (x["solennite"], x["annee"])
+    grouped = []
+    for key, group in itertools.groupby(entries, keyfunc):
+        grouped.append((key, list(group)))
+    return grouped
+
+def main():
+    with open(JSON_FILE, encoding="utf-8") as f:
+        data = json.load(f)
+
+    groups = group_entries(data)
+    final_doc = None
+    tmp_name = "_tmp.docx"
+
+    for (solennite, annee), items in groups:
+        tpl = DocxTemplate(TEMPLATE_FILE)
+        lectures = []
+        for i, item in enumerate(items):
+            lectures.append({
+                "titre": titre_lecture(i),
+                "ref": item["ref_bib"],
+                "mon": item["monition"],
+            })
+        context = {
+            "date": solennite,
+            "nom_fete": f"{solennite} – Année {annee}",
+            "lectures": lectures,
+        }
+        tpl.render(context)
+        tpl.save(tmp_name)
+        doc_part = Document(tmp_name)
+        if final_doc is None:
+            final_doc = doc_part
+        else:
+            for element in doc_part.element.body:
+                final_doc.element.body.append(element)
+        os.remove(tmp_name)
+
+    if final_doc is not None:
+        final_doc.save(OUTPUT_FILE)
+        print(f"Document généré : {OUTPUT_FILE}")
+    else:
+        print("Aucune donnée à traiter.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generer_livre.py` to create a consolidated Word document from `monitions_livre.json`
- document dependencies and usage of the new script

## Testing
- `python generer_livre.py`

------
https://chatgpt.com/codex/tasks/task_e_684074658b68832e9823dcfb4c1ef2a3